### PR TITLE
Curl header formatting and last_run_time logic

### DIFF
--- a/cloudflare_ddns
+++ b/cloudflare_ddns
@@ -31,9 +31,7 @@ log_output()
 list_dns_records()
 {
 	curl -s -X GET "https://api.cloudflare.com/client/v4/zones/$DNS_ZONE_ID/dns_records" \
-		-H @- <<- HEADERS
-			$CLOUDFLARE_AUTH_HEADERS
-		HEADERS
+		-H "$CLOUDFLARE_AUTH_HEADERS"
 }
 
 list_dns_records_onsuccess()
@@ -55,10 +53,9 @@ update_record()
 {
 	curl -s -X PUT "https://api.cloudflare.com/client/v4/zones/$DNS_ZONE_ID/dns_records/$DNS_RECORD_ID" \
 		--data "{\"type\":\"$DNS_RECORD_TYPE\",\"name\":\"$DNS_RECORD_NAME\",\"content\":\"$NEW_IP\",\"ttl\":1,\"proxied\":$DNS_RECORD_PROXIED}" \
-		-H @- <<- HEADERS
-			$CLOUDFLARE_AUTH_HEADERS
-			Content-Type: application/json
-		HEADERS
+		-H "$CLOUDFLARE_AUTH_HEADERS"
+		-H "Content-Type: application/json"
+		
 }
 
 update_record_onsuccess()
@@ -86,9 +83,13 @@ throttle()
 		return
 	fi
 
-	last_run_time=$(date -d "$(sort -r $LOGFILE | \
-		grep '^[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9] [0-9][0-9]:[0-9][0-9]' | \
-		grep -vm1 THROTTLED | cut -f 1)" +%s)
+        last_run_time=$(sort -nr $LOGFILE | \
+        awk -F'    ' '{OFS=FS;
+                        command="date -d" "\"" $1 "\"" " +%s";
+                        command | getline $1;
+                        close(command);
+                        print $1}' |
+        head -n1)
 	current_time=$(date +%s)
 	if [ $(expr $last_run_time + $THROTTLE_SECONDS) -gt $current_time ]; then
 		$throttled


### PR DESCRIPTION
1. Adjust curl header format to use -H option, the original ways reported syntax error on RT-AX86U running Merlin 386.3 with curl 7.76.1.
2. Rewrite last_run_time logic, using awk and date. The original way not working either.